### PR TITLE
Fixing android dialog error

### DIFF
--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -77,7 +77,8 @@ module.exports = function (ctx) {
 
       // Quasar plugins
       plugins: [
-        'Notify'
+        'Notify',
+        'Dialog'
       ]
 
       // iconSet: 'ionicons-v4'

--- a/src/pages/Intro/SaveToFile.vue
+++ b/src/pages/Intro/SaveToFile.vue
@@ -136,6 +136,7 @@
 
 <script>
 import configManager from '../../util/ConfigManager'
+import { devError } from 'src/util/errorHandler'
 
 export default {
   // name: 'ComponentName',
@@ -237,6 +238,7 @@ export default {
           }
         }
       } catch (e) {
+        devError(e)
         if (!this.nameAlreadyUsed) {
           this.passwordInvalid = true
           this.showSubmitButton = false


### PR DESCRIPTION
Adding dialog to the plugins (missed this on v0.17 > v1.0 upgrade)
and adding an error handler that way it's easy to debug next time